### PR TITLE
Auth Endpint: add a lambda to validate JWT

### DIFF
--- a/mp-backend/__tests__/handlers/auth.test.ts
+++ b/mp-backend/__tests__/handlers/auth.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { expect } from "@jest/globals";
-import { authenticate } from  "../../src/handlers/auth";
+import { authenticate, authenticateToken } from  "../../src/handlers/auth";
 import { createEvent } from  "../utils/event.handler";
 import { create } from '../../src/handlers/user'
 import dynamoDb from "../../src/libs/dynamodb-lib";
@@ -184,5 +183,80 @@ describe('authentication endpoint', () => {
         }
         const result = await authenticate(createEvent(event), Context(), () => {return});
         expect(result ? result.statusCode: false).toBe(400);
+    });
+});
+
+describe('authenticateJWT endpoint', () => {
+
+    interface LambdaResponse {
+        message: string
+    }
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env.PEPPER = 'SPICY';
+        process.env.JWTSECRET = 'SECRET';
+    });
+
+    afterAll(() => {
+        delete process.env.PEPPER;
+        delete process.env.JWTSECRET;
+        jest.resetAllMocks();
+        jest.resetModules();
+    });
+
+    it('accepts a known valid JWT', async () => {
+        const goodToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6OTk5OTk5OTk5OSwiaXNzIjoicHJlcCJ9.72jRsU8sOI1TBiC3GV5vW9bYb3Q6YFzd61H0nxxW7Ah1TnYOj6rzWfJR2di2YdA7ayM503XEubz2tYVOr19BJQ';
+        const event = {
+            pathParameters: {token: goodToken},
+            identity: {
+                userArn: 'testARN'
+            }
+        }
+
+        const result = await authenticateToken(createEvent(event), Context(), () => {return});
+        expect(result ? result.statusCode : false).toBe(200);
+        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Authorized");
+    });
+
+    it('declines a known invalid JWT', async () => {
+        const badToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6MCwiaXNzIjoicHJlcCJ9.Lkjq86oj1arh4Zhxc1qD7rBk47XPr9_Ou6Hj00NnguvE9M0GlsBkXu4W8TYQhasoxPMyXFI4YjaPs5D4C4P9tw';
+        const event = {
+            pathParameters: {token: badToken},
+            identity: {
+                userArn: 'testARN'
+            }
+        }
+
+        const result = await authenticateToken(createEvent(event), Context(), () => {return});
+        expect(result ? result.statusCode : false).toBe(401);
+        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Unauthorized");
+    });
+
+    it('declines a request with invalid pathParameters', async () => {
+        const badToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6MCwiaXNzIjoicHJlcCJ9.Lkjq86oj1arh4Zhxc1qD7rBk47XPr9_Ou6Hj00NnguvE9M0GlsBkXu4W8TYQhasoxPMyXFI4YjaPs5D4C4P9tw';
+        const event = {
+            pathParameters: {token2: badToken},
+            identity: {
+                userArn: 'testARN'
+            }
+        }
+
+        const result = await authenticateToken(createEvent(event), Context(), () => {return});
+        expect(result ? result.statusCode : false).toBe(401);
+        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Unauthorized");
+    });
+
+    it('declines a request with invalid identity', async () => {
+        const badToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6MCwiaXNzIjoicHJlcCJ9.Lkjq86oj1arh4Zhxc1qD7rBk47XPr9_Ou6Hj00NnguvE9M0GlsBkXu4W8TYQhasoxPMyXFI4YjaPs5D4C4P9tw';
+        const event = {
+            pathParameters: {token: badToken},
+            identity: {
+            }
+        }
+
+        const result = await authenticateToken(createEvent(event), Context(), () => {return});
+        expect(result ? result.statusCode : false).toBe(401);
+        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Unauthorized");
     });
 });

--- a/mp-backend/__tests__/handlers/auth.test.ts
+++ b/mp-backend/__tests__/handlers/auth.test.ts
@@ -192,71 +192,10 @@ describe('authenticateJWT endpoint', () => {
         message: string
     }
 
-    beforeEach(() => {
-        jest.resetModules();
-        process.env.PEPPER = 'SPICY';
-        process.env.JWTSECRET = 'SECRET';
-    });
-
-    afterAll(() => {
-        delete process.env.PEPPER;
-        delete process.env.JWTSECRET;
-        jest.resetAllMocks();
-        jest.resetModules();
-    });
-
-    it('accepts a known valid JWT', async () => {
-        const goodToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6OTk5OTk5OTk5OSwiaXNzIjoicHJlcCJ9.72jRsU8sOI1TBiC3GV5vW9bYb3Q6YFzd61H0nxxW7Ah1TnYOj6rzWfJR2di2YdA7ayM503XEubz2tYVOr19BJQ';
-        const event = {
-            pathParameters: {token: goodToken},
-            identity: {
-                userArn: 'testARN'
-            }
-        }
-
+    it('always returns success', async () => {
+        const event = {};
         const result = await authenticateToken(createEvent(event), Context(), () => {return});
         expect(result ? result.statusCode : false).toBe(200);
-        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Authorized");
-    });
-
-    it('declines a known invalid JWT', async () => {
-        const badToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6MCwiaXNzIjoicHJlcCJ9.Lkjq86oj1arh4Zhxc1qD7rBk47XPr9_Ou6Hj00NnguvE9M0GlsBkXu4W8TYQhasoxPMyXFI4YjaPs5D4C4P9tw';
-        const event = {
-            pathParameters: {token: badToken},
-            identity: {
-                userArn: 'testARN'
-            }
-        }
-
-        const result = await authenticateToken(createEvent(event), Context(), () => {return});
-        expect(result ? result.statusCode : false).toBe(401);
-        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Unauthorized");
-    });
-
-    it('declines a request with invalid pathParameters', async () => {
-        const badToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6MCwiaXNzIjoicHJlcCJ9.Lkjq86oj1arh4Zhxc1qD7rBk47XPr9_Ou6Hj00NnguvE9M0GlsBkXu4W8TYQhasoxPMyXFI4YjaPs5D4C4P9tw';
-        const event = {
-            pathParameters: {token2: badToken},
-            identity: {
-                userArn: 'testARN'
-            }
-        }
-
-        const result = await authenticateToken(createEvent(event), Context(), () => {return});
-        expect(result ? result.statusCode : false).toBe(401);
-        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Unauthorized");
-    });
-
-    it('declines a request with invalid identity', async () => {
-        const badToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzNjQyMjA3Mi0wMjYyLTQwYWQtOTc0Yy0yMzU5MjdjYzAxOTUiLCJpYXQiOjE2MDM4MTMyNjQsImV4cCI6MCwiaXNzIjoicHJlcCJ9.Lkjq86oj1arh4Zhxc1qD7rBk47XPr9_Ou6Hj00NnguvE9M0GlsBkXu4W8TYQhasoxPMyXFI4YjaPs5D4C4P9tw';
-        const event = {
-            pathParameters: {token: badToken},
-            identity: {
-            }
-        }
-
-        const result = await authenticateToken(createEvent(event), Context(), () => {return});
-        expect(result ? result.statusCode : false).toBe(401);
-        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("Unauthorized");
+        expect(result ? (<LambdaResponse>JSON.parse(result.body)).message : false).toBe("success");
     });
 });

--- a/mp-backend/__tests__/utils/event.handler.ts
+++ b/mp-backend/__tests__/utils/event.handler.ts
@@ -1,7 +1,11 @@
 import {  APIGatewayProxyEvent} from "aws-lambda";
 
 type Event = {
-    body?: string
+    body?: string,
+    pathParameters?: Record<string, string>
+    identity?: {
+        userArn?: string
+    }
 }
 export const createEvent = (event: Event): APIGatewayProxyEvent => {
     // create an event object that will allow us to be properly formatted for the handler function
@@ -12,7 +16,7 @@ export const createEvent = (event: Event): APIGatewayProxyEvent => {
         httpMethod: '',
         isBase64Encoded: false,
         path: '',
-        pathParameters: {test:''},
+        pathParameters: event.pathParameters || {test:''},
         queryStringParameters: {test:''},
         multiValueQueryStringParameters: {test:['']},
         stageVariables: {test:''},
@@ -37,7 +41,7 @@ export const createEvent = (event: Event): APIGatewayProxyEvent => {
                 sourceIp: '',
                 user: '',
                 userAgent: '',
-                userArn: '',
+                userArn: event.identity ? event.identity.userArn ? event.identity.userArn : '' : '',
             },
             stage: '', 
             requestId: '',

--- a/mp-backend/lambda-routes.yml
+++ b/mp-backend/lambda-routes.yml
@@ -37,7 +37,7 @@ authenticateToken:
     handler: src/handlers/auth.authenticateToken
     events:
         - http:
-            path: api/auth/{token}
+            path: api/auth
             method: get
             cors: true
-            authorizer: aws_iam
+            authorizer: authenticateJWT

--- a/mp-backend/lambda-routes.yml
+++ b/mp-backend/lambda-routes.yml
@@ -32,3 +32,12 @@ deleteUser:
             method: delete
             cors: true
             authorizer: aws_iam
+
+authenticateToken:
+    handler: src/handlers/auth.authenticateToken
+    events:
+        - http:
+            path: api/auth/{token}
+            method: get
+            cors: true
+            authorizer: aws_iam

--- a/mp-backend/src/handlers/auth.ts
+++ b/mp-backend/src/handlers/auth.ts
@@ -2,9 +2,6 @@ import { APIGatewayProxyHandler } from 'aws-lambda';
 import DynamoDB from 'aws-sdk/clients/dynamodb';
 import dynamoLib from '../libs/dynamodb-lib';
 import { authLib } from '../libs/authentication';
-import { APIGatewayTokenAuthorizerEvent } from 'aws-lambda/trigger/api-gateway-authorizer'
-import { APIGatewayProxyResult } from 'aws-lambda/trigger/api-gateway-proxy'
-import { authenticateJWT } from '../middleware/authenticateJWT'
 
 interface AuthEventBody extends DynamoDB.DocumentClient.PutItemInputAttributeMap {
     username: string,

--- a/mp-backend/src/handlers/auth.ts
+++ b/mp-backend/src/handlers/auth.ts
@@ -156,34 +156,9 @@ export const authenticate: APIGatewayProxyHandler = async (event) => {
     }
 };
 
-export const authenticateToken: APIGatewayProxyHandler = (event, context) => {
-    if(!event || !event.pathParameters || !event.pathParameters.token || !event.requestContext.identity.userArn) {
-        return Promise.resolve({
-            statusCode: 401,
-            body: JSON.stringify({message: "Unauthorized"})
-        });
-    }
-    
-    const token = event.pathParameters.token;
-    const authenticateEvent: APIGatewayTokenAuthorizerEvent = {
-        authorizationToken: 'bearer ' + token,
-        type: 'TOKEN',
-        methodArn: event.requestContext.identity.userArn
-    }
-
-    let result: APIGatewayProxyResult = {
-        statusCode: 401,
-        body: JSON.stringify({message: "Unauthorized"})
-    };
-
-    authenticateJWT(authenticateEvent, context, (err) => {
-        if(!err) {
-            result =  {
-                statusCode: 200,
-                body: JSON.stringify({message: "Authorized"})
-            }
-        }
+export const authenticateToken: APIGatewayProxyHandler = () => {
+    return Promise.resolve({
+        statusCode: 200,
+        body: JSON.stringify({message: "success"})
     });
-
-    return Promise.resolve(result);
 }


### PR DESCRIPTION
Adds a helper lambda that uses the existing middleware to make a decision about whether or not a JWT is valid.